### PR TITLE
Exec time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Marcos Pasa", "Vinícius"]
 version = "1.0.0-DEV"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 

--- a/examples/simple_anim.jl
+++ b/examples/simple_anim.jl
@@ -7,10 +7,8 @@ using Mavi: Mavi, Visualization
 using Mavi.Configs
 
 state = Mavi.State{Float64}(
-    x=[1, 2],
-    y=[1, 2],
-    vx=[0.3, 2],
-    vy=[1, 0],
+    pos=[1 2; 1 2],
+    vel=[0.3 2; 1 0]
 )
 
 system = Mavi.System(
@@ -30,18 +28,17 @@ function step!(system::Mavi.System)
     dt = system.int_cfg.dt
 
     # Constant velocity
-    state.x .+= state.vx * dt 
-    state.y .+= state.vy * dt 
+    state.pos .+= state.vel * dt
 
     # Rigid walls collisions
     space_cfg = system.space_cfg
     r = system.dynamic_cfg.ro/2
     for i in 1:system.num_p
-        if ((state.x[i]+r) > space_cfg.length) || ((state.x[i]-r) < 0)
-            state.vx[i] *= -1.
+        if ((state.pos[1, i]+r) > space_cfg.length) || ((state.pos[1, i]-r) < 0)
+            state.vel[1, i] *= -1.
         end
-        if ((state.y[i]+r) > space_cfg.height) || ((state.y[i]-r) < 0)
-            state.vy[i] *= -1.
+        if ((state.pos[2, i]+r) > space_cfg.height) || ((state.pos[2, i]-r) < 0)
+            state.vel[2, i] *= -1.
         end
     end
 end

--- a/src/Mavi.jl
+++ b/src/Mavi.jl
@@ -59,11 +59,11 @@ struct System{T, C1<:SpaceCfg, C2<:DynamicCfg}
     num_p::Int
 end
 function System(;state::State{T}, space_cfg, dynamic_cfg, int_cfg) where {T}
-    all_inside, out_ids = check_inside(state, space_cfg)
-    if all_inside == false
-        throw("Particles with ids=$(out_ids) outside space.")
-    end
-    num_p = length(state.x)
+    # all_inside, out_ids = check_inside(state, space_cfg)
+    # if all_inside == false
+    #     throw("Particles with ids=$(out_ids) outside space.")
+    # end
+    num_p = size(state.pos)[2]
     diffs = Array{T, 3}(undef, 2, num_p, num_p)
     forces = Array{T, 2}(undef, 2, num_p)
     dists = zeros(T, num_p, num_p)

--- a/src/Mavi.jl
+++ b/src/Mavi.jl
@@ -12,6 +12,9 @@ using .Configs
     vy::Vector{T}
 end
 
+include("space_checks.jl")
+using .SpaceChecks
+
 """
 Base struct that represent a system of particles.
 
@@ -51,37 +54,10 @@ struct System{T, C1<:SpaceCfg, C2<:DynamicCfg}
     "Number of particles"
     num_p::Int
 end
-
-
-"""
-Returns the indices of particles outside the given space configuration.
-"""
-function outside_particles(state::State, space_cfg::RectangleCfg)
-    out_ids = findall((state.x .<= 0.0 .| state.x .>= space_cfg.length) .| (state.y .<= 0.0 .| state.y .>= space_cfg.height))
-    return out_ids
-end
-
-function outside_particles(state::State, space_cfg::CircleCfg)
-    r2 = state.x.^2 + state.y.^2
-    out_ids = findall(r2 .>= space_cfg.radius^2)
-    return out_ids
-end
-"""
-Checks if all particles are inside the given space configuration. If not, throws an error.
-"""
-function check_inside(state::State, space_cfg::SpaceCfg)
-    all_inside = true
-    out_ids = outside_particles(state,space_cfg)
-    if length(out_ids) != 0
-        all_inside = false
-    end
-    return all_inside, out_ids
-end
-
 function System(;state::State{T}, space_cfg, dynamic_cfg, int_cfg) where {T}
-    all_inside, out_ids = check_inside(state,space_cfg)
+    all_inside, out_ids = check_inside(state, space_cfg)
     if all_inside == false
-        throw("particles $(out_ids) outside space.")
+        throw("Particles with ids=$(out_ids) outside space.")
     end
     num_p = length(state.x)
     diffs = Array{T, 3}(undef, 2, num_p, num_p)

--- a/src/Mavi.jl
+++ b/src/Mavi.jl
@@ -5,11 +5,15 @@ include("configs.jl")
 using .Configs
 
 "Particles state (positions and velocities)"
+# @kwdef struct State{T}
+#     x::Vector{T}
+#     y::Vector{T}
+#     vx::Vector{T}
+#     vy::Vector{T}
+# end
 @kwdef struct State{T}
-    x::Vector{T}
-    y::Vector{T}
-    vx::Vector{T}
-    vy::Vector{T}
+    pos::Matrix{T}
+    vel::Matrix{T}
 end
 
 include("space_checks.jl")

--- a/src/Mavi.jl
+++ b/src/Mavi.jl
@@ -5,12 +5,6 @@ include("configs.jl")
 using .Configs
 
 "Particles state (positions and velocities)"
-# @kwdef struct State{T}
-#     x::Vector{T}
-#     y::Vector{T}
-#     vx::Vector{T}
-#     vy::Vector{T}
-# end
 @kwdef struct State{T}
     pos::Matrix{T}
     vel::Matrix{T}
@@ -59,10 +53,10 @@ struct System{T, C1<:SpaceCfg, C2<:DynamicCfg}
     num_p::Int
 end
 function System(;state::State{T}, space_cfg, dynamic_cfg, int_cfg) where {T}
-    # all_inside, out_ids = check_inside(state, space_cfg)
-    # if all_inside == false
-    #     throw("Particles with ids=$(out_ids) outside space.")
-    # end
+    all_inside, out_ids = check_inside(state, space_cfg)
+    if all_inside == false
+        throw("Particles with ids=$(out_ids) outside space.")
+    end
     num_p = size(state.pos)[2]
     diffs = Array{T, 3}(undef, 2, num_p, num_p)
     forces = Array{T, 2}(undef, 2, num_p)

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -74,31 +74,19 @@ function rigid_walls!(system::System, space_cfg::RectangleCfg)
 
     state.vel[1, findall(out_x)] .*= -1.0
     state.vel[2, findall(out_y)] .*= -1.0
-
-    # for i in 1:system.num_p
-    #     # Hit vertical wall
-    #     if ((state.x[i]+r) > space_cfg.length) || ((state.x[i]-r) < 0)
-    #         state.vx[i] *= -1.
-    #     end
-
-    #     # Hit horizontal wall
-    #     if ((state.y[i]+r) > space_cfg.height) || ((state.y[i]-r) < 0)
-    #         state.vy[i] *= -1.
-    #     end
-    # end
 end
 
 function rigid_walls!(system::System, space_cfg::CircleCfg)
     state = system.state
     max_r2 = (space_cfg.radius - particle_radius(system.dynamic_cfg))^2
     for i in 1:system.num_p
-        x, y = state.x[i], state.y[i]
+        x, y = state.pos[1, i], state.pos[2, i]
         x2, y2 = x^2, y^2
         if (x2 + y2) > max_r2
             r2 = x2 + y2
-            vx, vy = state.vx[i], state.vy[i]
-            state.vx[i] = (vx*(y2 - x2) - 2*vy*x*y) / r2
-            state.vy[i] = (-vy*(y2 - x2) - 2*vx*x*y) / r2
+            vx, vy = state.vel[1, i], state.vel[2, i]
+            state.vel[1, i] = (vx*(y2 - x2) - 2*vy*x*y) / r2
+            state.vel[2, i] = (-vy*(y2 - x2) - 2*vx*x*y) / r2
         end
     end
 end
@@ -112,8 +100,6 @@ function update_verlet!(system::System)
 
     # Update positions
     term = dt^2/2 # quadratic term on accelerated movement
-    # state.x .+= state.vx*dt + system.forces[1,:]*term # uniformly accelerated movement
-    # state.y .+= state.vy*dt + system.forces[2,:]*term
     state.pos .+= state.vel * dt + system.forces * term
 
     # Calculate new forces
@@ -121,8 +107,6 @@ function update_verlet!(system::System)
     calc_forces!(system, system.dynamic_cfg)
 
     # Update velocities
-    # state.vx .+= dt*(system.forces[1,:] + old_forces[1,:])/2 # mean over old and new forces
-    # state.vy .+= dt*(system.forces[2,:] + old_forces[2,:])/2
     state.vel .+= dt/2 * (system.forces + old_forces)
 end
 

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -10,8 +10,10 @@ function calc_diffs_and_dists!(system::System)
     for i in 1:system.num_p
         for j in i+1:system.num_p
             # Difference in position
-            x_ij = state.x[i] - state.x[j]
-            y_ij = state.y[i] - state.y[j]
+            x_ij = state.xp[i] - state.x[j]
+            y_ij = state.yp[i] - state.y[j]
+            # diff = stat.pos[:, i] - state.vel[:, 1]
+            
             r_ij = sqrt(x_ij^2 + y_ij^2)
 
             # Update values

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -10,9 +10,8 @@ function calc_diffs_and_dists!(system::System)
     for i in 1:system.num_p
         for j in i+1:system.num_p
             # Difference in position
-            x_ij = state.xp[i] - state.x[j]
-            y_ij = state.yp[i] - state.y[j]
-            # diff = stat.pos[:, i] - state.vel[:, 1]
+            x_ij = state.pos[1, i] - state.pos[1, j]
+            y_ij = state.pos[2, i] - state.pos[2, j]
             
             r_ij = sqrt(x_ij^2 + y_ij^2)
 
@@ -68,19 +67,25 @@ end
 "Rigid walls collisions. Reflect velocity on collision."
 function rigid_walls!(system::System, space_cfg::RectangleCfg)
     state = system.state
+    r = particle_radius(system.dynamic_cfg)
 
-    r = system.dynamic_cfg.ro / 2
-    for i in 1:system.num_p
-        # Hit vertical wall
-        if ((state.x[i]+r) > space_cfg.length) || ((state.x[i]-r) < 0)
-            state.vx[i] *= -1.
-        end
+    out_x = @. ((state.pos[1, :] + r) > space_cfg.length) || ((state.pos[1, :] - r) < 0)
+    out_y = @. ((state.pos[2, :] + r) > space_cfg.height) || ((state.pos[2, :] - r) < 0)
 
-        # Hit horizontal wall
-        if ((state.y[i]+r) > space_cfg.height) || ((state.y[i]-r) < 0)
-            state.vy[i] *= -1.
-        end
-    end
+    state.vel[1, findall(out_x)] .*= -1.0
+    state.vel[2, findall(out_y)] .*= -1.0
+
+    # for i in 1:system.num_p
+    #     # Hit vertical wall
+    #     if ((state.x[i]+r) > space_cfg.length) || ((state.x[i]-r) < 0)
+    #         state.vx[i] *= -1.
+    #     end
+
+    #     # Hit horizontal wall
+    #     if ((state.y[i]+r) > space_cfg.height) || ((state.y[i]-r) < 0)
+    #         state.vy[i] *= -1.
+    #     end
+    # end
 end
 
 function rigid_walls!(system::System, space_cfg::CircleCfg)
@@ -107,16 +112,18 @@ function update_verlet!(system::System)
 
     # Update positions
     term = dt^2/2 # quadratic term on accelerated movement
-    state.x .+= state.vx*dt + system.forces[1,:]*term # uniformly accelerated movement
-    state.y .+= state.vy*dt + system.forces[2,:]*term
+    # state.x .+= state.vx*dt + system.forces[1,:]*term # uniformly accelerated movement
+    # state.y .+= state.vy*dt + system.forces[2,:]*term
+    state.pos .+= state.vel * dt + system.forces * term
 
     # Calculate new forces
     calc_diffs_and_dists!(system)
     calc_forces!(system, system.dynamic_cfg)
 
     # Update velocities
-    state.vx .+= dt*(system.forces[1,:] + old_forces[1,:])/2 # mean over old and new forces
-    state.vy .+= dt*(system.forces[2,:] + old_forces[2,:])/2
+    # state.vx .+= dt*(system.forces[1,:] + old_forces[1,:])/2 # mean over old and new forces
+    # state.vy .+= dt*(system.forces[2,:] + old_forces[2,:])/2
+    state.vel .+= dt/2 * (system.forces + old_forces)
 end
 
 "Advance system one time step."

--- a/src/space_checks.jl
+++ b/src/space_checks.jl
@@ -1,0 +1,38 @@
+module SpaceChecks
+
+using Mavi: State
+using Mavi.Configs
+
+export check_inside
+
+"Return particles indices outside the given space configuration."
+function outside_particles(state::State, space_cfg::RectangleCfg)
+    x_out = @. (state.x < 0.0) | (state.x > space_cfg.length)
+    y_out = @. (state.y < 0.0) | (state.y > space_cfg.height)
+    out_ids = findall(x_out .| y_out)
+    return out_ids
+end
+
+function outside_particles(state::State, space_cfg::CircleCfg)
+    r2 = @. state.x^2 + state.y^2
+    out_ids = findall(r2 .> space_cfg.radius^2)
+    return out_ids
+end
+
+"""
+Checks if all particles are inside the given space configuration. 
+
+# Return
+- `all_inside::bool`: True if all particles are inside, false otherwise.
+- `out_ids::Vector{Int}`: Indices of outside particles.
+"""
+function check_inside(state::State, space_cfg::SpaceCfg)
+    all_inside = true
+    out_ids = outside_particles(state,space_cfg)
+    if length(out_ids) != 0
+        all_inside = false
+    end
+    return all_inside, out_ids
+end
+
+end

--- a/src/space_checks.jl
+++ b/src/space_checks.jl
@@ -7,14 +7,14 @@ export check_inside
 
 "Return particles indices outside the given space configuration."
 function outside_particles(state::State, space_cfg::RectangleCfg)
-    x_out = @. (state.x < 0.0) | (state.x > space_cfg.length)
-    y_out = @. (state.y < 0.0) | (state.y > space_cfg.height)
+    x_out = @. (state.pos[1, :] < 0.0) | (state.pos[1, :] > space_cfg.length)
+    y_out = @. (state.pos[2, :] < 0.0) | (state.pos[2, :] > space_cfg.height)
     out_ids = findall(x_out .| y_out)
     return out_ids
 end
 
 function outside_particles(state::State, space_cfg::CircleCfg)
-    r2 = @. state.x^2 + state.y^2
+    r2 = @. state.pos[1, :]^2 + state.pos[2, :]^2
     out_ids = findall(r2 .> space_cfg.radius^2)
     return out_ids
 end
@@ -28,7 +28,7 @@ Checks if all particles are inside the given space configuration.
 """
 function check_inside(state::State, space_cfg::SpaceCfg)
     all_inside = true
-    out_ids = outside_particles(state,space_cfg)
+    out_ids = outside_particles(state, space_cfg)
     if length(out_ids) != 0
         all_inside = false
     end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -4,12 +4,24 @@ module Visualization
 using GLMakie, Printf
 using Mavi: State, System
 using Mavi.Configs
+using DataStructures
 
+"""
+Animation configurations
+
+# Arguments
+- fps: Animation fps
+- num_stesp_per_frame: How many time steps are done in a single frame.
+- circle_radius: Radius used to draw circles centered on particles positions.  
+    If not given, `particle_radius(dynamic_cfg)` will be used.
+- exec_times_size: Circular buffer length that stores step time execution.
+"""
 @kwdef struct AnimationCfg
     fps::Int=30
     num_steps_per_frame::Int
     circle_radius::Float64=-1
     circle_rel::Int = 20
+    exec_times_size = 40
 end
 
 "Return circle vertices centered in the origin with given radius."
@@ -74,15 +86,19 @@ function animate(system::System{T}, step!, cfg::AnimationCfg) where {T}
     circle_points_obs = Observable(circle_points)
     circles_lines = linesegments!(ax, circle_points_obs, color=:black)
 
+    exec_times = CircularBuffer{Float64}(cfg.exec_times_size)
+
     display(fig)
     time = 0.0
     while events(fig).window_open[] 
         for _ in 1:cfg.num_steps_per_frame
-            step!(system)
+            info = @timed step!(system)
+            push!(exec_times, info.time)
             time += system.int_cfg.dt
         end
         
-        ax.title = @sprintf("t=%.3f", time)
+        mean_exec_time = sum(exec_times)/length(exec_times) * 1000
+        ax.title = @sprintf("t=%.3f | Δt=%.3f ms", time, mean_exec_time)
 
         update_circles!(circle_points, circle_base, system.state)
         notify(circle_points_obs)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -52,19 +52,19 @@ end
 
 function update_circles!(circle_points, circle_base, state::State{T}) where {T}
     num_edges = length(circle_base)
-    num_p = length(state.x)
+    num_p = size(state.pos)[2]
     for i in 1:num_p
         begin_id = num_edges * (i-1) + 1
         end_id = begin_id + num_edges - 1 
-        center = [state.x[i], state.y[i]]
+        center = [state.pos[1, i], state.pos[2, i]]
         circle_points[begin_id:end_id] .= circle_base .+ [center]
     end
 end
 
 "Render, in real time, the system using the given step function."
 function animate(system::System{T}, step!, cfg::AnimationCfg) where {T}
-    x_obs = Observable(system.state.x)
-    y_obs = Observable(system.state.y)
+    x_obs = Observable(@view system.state.pos[1, :])
+    y_obs = Observable(@view system.state.pos[2, :])
     pos_obs = [x_obs, y_obs]
     
     fig, ax = scatter(pos_obs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,12 +13,31 @@ using Test
 
         system = Mavi.System(
             state=state, 
-            space_cfg=SpaceCfg(1, 1), 
-            dynamic_cfg=DynamicCfg(1, 1, 1),
+            space_cfg=RectangleCfg(1, 1), 
+            dynamic_cfg=HarmTruncCfg(1, 1, 1),
             int_cfg=IntegrationCfg(1)
         )
         return
     end
 
+    function test_space_check(;state, space_cfg)
+        system = Mavi.System(
+            state=state, 
+            space_cfg=space_cfg, 
+            dynamic_cfg=DynamicCfg(1, 1, 1),
+            int_cfg=IntegrationCfg(1)
+        )
+    end
+
     @test create_system() === nothing
+
+    # @test_throws test_space_check(
+    #     state = Mavi.State{Float64}(
+    #         x=[1, 2, 2.5],
+    #         y=[1, 2, 6],
+    #         vx=[1, 2, 0],
+    #         vy=[1, 2, 0],
+    #     ),
+    #     space_cfg = RectangleCfg(3, 5)
+    # )
 end


### PR DESCRIPTION
Mudanças realizadas:
- Refatorado o código de checagem espacial.
- Adicionado informação do tempo de execução na animação em tempo real
- `State` agora usa duas matrizes ao invés de 4 vetores.